### PR TITLE
fix: force-clean and normalize validation notebooks (supersedes #9-#14)

### DIFF
--- a/notebooks/validation/phaseB/TalbotCarpet_SideBand_Test.ipynb
+++ b/notebooks/validation/phaseB/TalbotCarpet_SideBand_Test.ipynb
@@ -36,7 +36,13 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/notebooks/validation/synthetic/Noise_Sweep_ROC.ipynb
+++ b/notebooks/validation/synthetic/Noise_Sweep_ROC.ipynb
@@ -105,6 +105,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "name": "python"
   }


### PR DESCRIPTION
**What's inside**\n* Converts ALL VS-Code XML notebooks to nbformat-v4 JSON\n* Strips control chars & residual <VSCode.Cell> tags\n* Injects robust hann import fallback (signal.windows → signal → NumPy)\n* Adds Python-3 kernelspec metadata\n\nThis PR replaces and closes PRs #9 #10 #11 #12 #13 #14.